### PR TITLE
Add parsing for excess generation if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ GigyaAuthenticator(
 class IntervalUsageData:
     timestamp: datetime  # Start of 30-minute interval
     consumption: float   # kWh consumed
-    unit: str           # "kWh"
+    generation: float    # kWh excess generation returned to grid
+    unit: str            # "kWh"
 ```
 
 ### Exceptions
@@ -341,11 +342,11 @@ ApiError                     # API returned error
 The API returns 30-minute interval data. Example output:
 
 ```
-Timestamp                 Consumption    Unit
----------------------------------------------
-2024-01-15 00:00          0.45           kWh
-2024-01-15 00:30          0.38           kWh
-2024-01-15 01:00          0.42           kWh
+Timestamp                  Consumption   Generation Unit  
+---------------------------------------------------------
+2024-01-15 00:00                  0.45         0.01 kWh
+2024-01-15 00:30                  0.38         0.00 kWh
+2024-01-15 01:00                  0.42         0.01 kWh
 ...
 ```
 

--- a/dompower/__main__.py
+++ b/dompower/__main__.py
@@ -369,6 +369,7 @@ async def cmd_usage(args: argparse.Namespace) -> int:
                     {
                         "timestamp": u.timestamp.isoformat(),
                         "consumption": u.consumption,
+                        "generation": u.generation,
                         "unit": u.unit,
                     }
                     for u in usage_data
@@ -378,12 +379,12 @@ async def cmd_usage(args: argparse.Namespace) -> int:
                 print(f"Usage data from {start_date} to {end_date}")
                 print(f"Total records: {len(usage_data)}")
                 print()
-                print(f"{'Timestamp':<25} {'Consumption':>12} {'Unit':<6}")
-                print("-" * 45)
+                print(f"{'Timestamp':<25} {'Consumption':>12} {'Generation':12} {'Unit':<6}")
+                print("-" * 57)
                 for u in usage_data[:20]:  # Show first 20
                     print(
                         f"{u.timestamp.strftime('%Y-%m-%d %H:%M'):<25} "
-                        f"{u.consumption:>12.2f} {u.unit:<6}"
+                        f"{u.consumption:>12.2f} {u.generation:>12.2f} {u.unit:<6}"
                     )
                 if len(usage_data) > 20:
                     print(f"... and {len(usage_data) - 20} more records")

--- a/dompower/__main__.py
+++ b/dompower/__main__.py
@@ -379,7 +379,8 @@ async def cmd_usage(args: argparse.Namespace) -> int:
                 print(f"Usage data from {start_date} to {end_date}")
                 print(f"Total records: {len(usage_data)}")
                 print()
-                print(f"{'Timestamp':<25} {'Consumption':>12} {'Generation':12} {'Unit':<6}")
+                print(f"{'Timestamp':<25} {'Consumption':>12} "
+                      f"{'Generation':>12} {'Unit':<6}")
                 print("-" * 57)
                 for u in usage_data[:20]:  # Show first 20
                     print(

--- a/dompower/client.py
+++ b/dompower/client.py
@@ -459,6 +459,7 @@ class DompowerClient:
                     IntervalUsageData(
                         timestamp=timestamp,
                         consumption=consumption,
+                        generation=0,
                         unit="kWh",
                     )
                 )

--- a/dompower/client.py
+++ b/dompower/client.py
@@ -389,13 +389,14 @@ class DompowerClient:
 
         workbook = openpyxl.load_workbook(io.BytesIO(excel_data), data_only=True)
         consumption_sheet = workbook.active
-        generation_sheet = workbook["kWH Generation"]
 
         if consumption_sheet is None:
             return []
 
         # parse data from an arbitrary worksheet into a dict for later recombining
-        def _parse_worksheet(sheet: openpyxl.WorkSheet) -> dict[datetime, float]:
+        def _parse_worksheet(
+            sheet: openpyxl.worksheet.worksheet.Worksheet
+        ) -> dict[datetime, float]:
             return_dict: dict[datetime, float] = {}
 
             # Get header row to parse time slots
@@ -464,8 +465,8 @@ class DompowerClient:
 
         consumption_dict = _parse_worksheet(consumption_sheet)
 
-        if generation_sheet is not None:
-            generation_dict = _parse_worksheet(generation_sheet)
+        if "kWH Generation" in workbook.sheetnames:
+            generation_dict = _parse_worksheet(workbook["kWH Generation"])
         else:
             generation_dict = {}
 

--- a/dompower/models.py
+++ b/dompower/models.py
@@ -103,11 +103,13 @@ class IntervalUsageData:
     Attributes:
         timestamp: Start time of the 30-minute interval.
         consumption: Amount of energy consumed in kWh.
+        generation: Excess energy generated and returned to Dominion in kWh.
         unit: Unit of measurement (typically "kWh").
     """
 
     timestamp: datetime
     consumption: float
+    generation: float
     unit: str = "kWh"
 
 

--- a/dompower/models.py
+++ b/dompower/models.py
@@ -109,7 +109,7 @@ class IntervalUsageData:
 
     timestamp: datetime
     consumption: float
-    generation: float
+    generation: float = 0.0
     unit: str = "kWh"
 
 


### PR DESCRIPTION
First step to address https://github.com/YeomansIII/ha-dominion-energy/issues/11

Adds the capability to parse out the "KWh Generation" sheet Dominion includes if a customer has net metering available (such as for solar panel owners).

Adds the generation as a new field on IntervalUsageData, and includes the new field in existing tabular/json text output.
If the sheet is not present, all `generation` values will be 0.

Updates references in the readme to include the new field. I didn't see any relevant tests to update, so no changes there.